### PR TITLE
Upgrade Babel to upgrade Regenerator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "lib/index",
   "dependencies": {
-    "babel-runtime": "5.4.4",
+    "babel-runtime": "^5.5.6",
     "bluebird": "^2.0",
     "debug": "^2.0",
     "fivebeans": "^1.2",
@@ -17,7 +17,7 @@
     "pretty-hrtime": "^1.0"
   },
   "devDependencies": {
-    "babel": "5.4.4",
+    "babel": "^5.5.6",
     "del": "^1.2.0",
     "gulp": "^3.8.10",
     "gulp-babel": "^5.1.0",


### PR DESCRIPTION
To avoid `_regeneratorRuntime.awrap is not a function` errors.
