### PR TITLE
Keep-alive for IronMQ

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -23,6 +23,7 @@ module.exports = class Configuration {
       this.queues.width     = source.queues.width || 1;
       this.queues.hostname  = source.queues.hostname;
       this.queues.port      = source.queues.port;
+      this.queues.keepAlive = source.queues.keepAlive || '30000';
     }
     // Apply defaults.
     if (!this.queues.hasOwnProperty('prefix'))

--- a/src/queues.js
+++ b/src/queues.js
@@ -559,6 +559,10 @@ class Queue extends EventEmitter {
     } catch(ex) {
     }
 
+    const keepAliveInterval = setInterval(()=> {
+      session.request('list_tubes_watched').catch(this._notify.debug);
+    }, parseInt(this._config.keepAlive));
+
     try {
 
       this._notify.info('Processing queued job %s:%s', this.name, jobID);
@@ -597,6 +601,8 @@ class Queue extends EventEmitter {
     // Remove job from queue: there's nothing we can do about an error here
     try {
       await session.request('destroy', jobID);
+      // Stop keeping the connection alive once we removed the job.
+      clearInterval(keepAliveInterval);
     } catch (destroyError) {
       this._notify.info('Could not delete job %s:%s', this.name, jobID, destroyError);
     }

--- a/src/queues.js
+++ b/src/queues.js
@@ -582,6 +582,7 @@ class Queue extends EventEmitter {
       // in the queue for a while before it becomes available again.
       const priority  = 0;
       const delay     = ifProduction(RELEASE_DELAY);
+      clearInterval(keepAliveInterval);
       try {
         await session.request('release', jobID, priority, msToSec(delay));
       } catch (releaseError) {
@@ -598,11 +599,10 @@ class Queue extends EventEmitter {
       throw error;
     }
 
+    clearInterval(keepAliveInterval);
     // Remove job from queue: there's nothing we can do about an error here
     try {
       await session.request('destroy', jobID);
-      // Stop keeping the connection alive once we removed the job.
-      clearInterval(keepAliveInterval);
     } catch (destroyError) {
       this._notify.info('Could not delete job %s:%s', this.name, jobID, destroyError);
     }

--- a/test/keep_alive_test.js
+++ b/test/keep_alive_test.js
@@ -84,10 +84,10 @@ describe('Server with keep-alive needs', ()=> {
 
   before(() => {
     Ironium.configure({
-      queues: { hostname: '127.0.0.1', port: 11333, keepAlive: '1500' }
+      queues: { hostname: '127.0.0.1', port: 11334, keepAlive: '1500' }
     });
 
-    mock.listen(11333);
+    mock.listen(11334);
   });
 
   describe('long-running jobs', ()=> {

--- a/test/keep_alive_test.js
+++ b/test/keep_alive_test.js
@@ -1,0 +1,115 @@
+require('./helpers');
+const assert   = require('assert');
+const Bluebird = require('bluebird');
+const Ironium  = require('../src');
+const Net      = require('net');
+
+const reserved = new Map();
+let   jobs     = 0;
+
+// This Beanstalk mock behaves like IronMQ with respect to connection handling:
+//
+// - It will drop the connection if no data is received within 2 seconds
+//   (IronMQ does 60 seconds).
+//
+// - Jobs can only be deleted from the connection that reserved them.
+//
+// For easier testing, this server emulates a queue with a single job
+// to be processed (so that you can call runOnce and drain it).
+//
+const mock = Net.createServer(function(socket) {
+  let killer;
+
+  socket.on('data', function(data) {
+    if (killer)
+      clearTimeout(killer);
+
+    const parts = data.toString().replace(/\r\n$/, '').split(' ');
+    const cmd   = parts[0];
+    let   reply;
+
+    switch (cmd) {
+      case 'use':
+        reply = `USING ${parts[1]}`;
+        break;
+      case 'watch':
+      case 'ignore':
+        reply = `WATCHING 1`;
+        break;
+      case 'list-tubes-watched':
+        reply = 'OK 0';
+        break;
+      case 'peek-ready':
+      case 'peek-delayed':
+        if (jobs === 0)
+          reply = `FOUND ${jobs} 3\r\nfoo`;
+        else
+          reply = 'NOT_FOUND';
+        break;
+      case 'reserve':
+      case 'reserve-with-timeout':
+        if (jobs === 0) {
+          jobs++;
+          reply = `RESERVED ${reserved.size} 3\r\nfoo`;
+          reserved.set(socket, 1);
+        }
+        else
+          reply = 'TIMED_OUT';
+        break;
+      case 'delete':
+        if (reserved.has(socket)) {
+          reply = `DELETED`;
+          reserved.delete(socket);
+        }
+        else
+          reply = 'NOT_FOUND';
+        break;
+      default:
+        throw new Error(`Unknown mock command "${cmd}".`);
+    }
+
+    if (reply)
+      socket.write(`${reply}\r\n`);
+
+    killer = setTimeout(function() {
+      socket.end();
+    }, 2000);
+  });
+
+  socket.unref();
+});
+
+
+describe('Server with keep-alive needs', ()=> {
+
+  before(() => {
+    Ironium.configure({
+      queues: { hostname: '127.0.0.1', port: 11333, keepAlive: '1500' }
+    });
+
+    mock.listen(11333);
+  });
+
+  describe('long-running jobs', ()=> {
+
+    it('should be processed and deleted', async ()=> {
+      Ironium.queue('foo').eachJob(async (body)=> {
+        assert.equal(reserved.size, 1);
+        await Bluebird.delay(3000);
+      });
+
+      await Ironium.runOnce();
+
+      assert.equal(reserved.size, 0);
+    });
+
+  });
+
+  after(() => {
+    Ironium.configure({
+      queues: { hostname: '127.0.0.1', port: 11300 }
+    });
+  });
+
+});
+


### PR DESCRIPTION
So that long-running (> 1m) jobs can be deleted.
