### PR TITLE
Updating iron-cache to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bluebird": "^3.0",
     "debug": "^2.2",
     "fivebeans": "^1.4",
-    "iron-cache": "^0.2.3",
+    "iron-cache": "^0.3.0",
     "iron_mq": "^0.9.2",
     "ms": "^0.7",
     "pretty-hrtime": "^1.0"


### PR DESCRIPTION
Please update [iron-cache](https://npmjs.org/package/iron-cache) to version 0.3.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`2ce8b12`](https://github.com/fiveisprime/iron-cache/commit/2ce8b12e52d14ee908787552cf32f5f8d3109e24) `0.3.0`
- [`419479d`](https://github.com/fiveisprime/iron-cache/commit/419479d15aeffd79fd45805109cbfd01a4ed5ca2) `Merge pull request #4 from djanowski/upgrade-request`
- [`b9fcf58`](https://github.com/fiveisprime/iron-cache/commit/b9fcf5859475249c8a5d7803e21a91bb88c277f5) `Upgrade vulnerable Request.`

View the [change log](https://github.com/fiveisprime/iron-cache/compare/f2f4aa320255c0a2d3566481d4fce5dd57a4e28a...2ce8b12e52d14ee908787552cf32f5f8d3109e24).
