### PR TITLE
Add processing concurrency

### DIFF
--- a/lib/beanstalk.js
+++ b/lib/beanstalk.js
@@ -246,7 +246,7 @@ module.exports = class Beanstalk {
 
   clear(callback) {
     return new Promise((resolve, reject) => {
-      this.peek({ n: 100 }, (error, ids) => {
+      this.peek({}, (error, ids) => {
         if (error && /not.found/i.test(error))
           resolve();
         else if (error)

--- a/lib/beanstalk.js
+++ b/lib/beanstalk.js
@@ -244,5 +244,23 @@ module.exports = class Beanstalk {
       });
   }
 
+  clear(callback) {
+    return new Promise((resolve, reject) => {
+      this.peek({ n: 100 }, (error, ids) => {
+        if (error && /not.found/i.test(error))
+          resolve();
+        else if (error)
+          reject(error);
+        else if (ids.length) {
+          const deleteEach  = ids.map(id => this.request('destroy', id));
+          const deleteAll   = Promise.all(deleteEach);
+          const andRepeat   = deleteAll.then(() => this.peekAndDelete());
+          resolve(andRepeat);
+        } else
+          resolve();
+      });
+    }).then(() => callback(), callback);
+  }
+
 };
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -19,7 +19,8 @@ module.exports = class Configuration {
   constructor(config) {
     config = config || {}; // eslint-disable-line no-param-reassign
 
-    this.prefix  = config.prefix || (process.env.NODE_ENV === 'test' ? QUEUE_TEST_PREFIX : '') || '';
+    this.prefix      = config.prefix || (process.env.NODE_ENV === 'test' ? QUEUE_TEST_PREFIX : '') || '';
+    this.concurrency = config.concurrency || 10;
 
     if (config.project_id || config.token) {
       // Configurating for IronMQ similar to iron.json

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -136,6 +136,8 @@ class Queue {
 
     this._handlers    = new Set();
     this._processing  = false;
+    this._reserving   = false;
+    this._activeJobs  = 0;
 
     // Used to limit concurrency for stream processing (see throttle method)
     this._queuing     = 0;
@@ -274,7 +276,7 @@ class Queue {
   //
   // Resolves to true if any job was processed, false otherwise.
   _reserveAndProcess(client) {
-    return this._reserveJob(client, 0)
+    return this._reserveJob(client, 0, 1)
       .then(job => {
         if (job) {
           return this._runAndDestroy(client, job)
@@ -288,33 +290,56 @@ class Queue {
 
   // Calls _processContinuously for each session
   _startProcessing() {
-    this._server.configPromise
-      .then(config => {
-        this._getClientPromise
-          .then(client => {
-            for (let i = 0; i < config.concurrency; ++i)
-              this._processContinuously(client);
-            return null;
-          });
-      });
+    this._getClientPromise
+      .then(client => {
+        this._processContinuously(client);
+        return null;
+      })
   }
 
   // Called to process all jobs, until this._processing is set to false.
   _processContinuously(client) {
-    const hasHandlers = (this._handlers.size > 0);
-    if (this._processing && hasHandlers) {
+    if (this._processing && !this._reserving) {
+      this._reserving = true;
 
-      debug('Waiting for jobs on queue %s', this.name);
       const backoff = ifProduction(RESERVE_BACKOFF);
       const wait    = (process.env.NODE_ENV === 'test' ? 0 : msToSec(RESERVE_WAIT));
-      this._reserveJob(client, wait)
-        .then(job => {
-          if (this._processing)
-            return this._runAndDestroy(client, job);
-          else
-            return releaseJob(job);
+
+      this._server.configPromise
+        .then(config => {
+          const maxJobs = config.concurrency - this._activeJobs;
+
+          if (maxJobs > 0) {
+            debug('Waiting for jobs on queue %s (max %s)', this.name, maxJobs);
+            return this._reserveJob(client, wait, maxJobs);
+          } else {
+            debug('%s out of %s jobs running, nothing to do', this._activeJobs, config.concurrency);
+            return Bluebird.delay(10).then(() => []);
+          }
         })
-        .catch(() => Bluebird.delay(backoff))
+        .then(jobOrJobs => {
+          this._reserving = false;
+          // With Beanstalk, or when n=1, we get a single job.
+          // Job objects are never arrays (their body could be).
+          const jobsArray = Array.isArray(jobOrJobs) ? jobOrJobs : [jobOrJobs];
+          // We can get a null job after the wait timeout.
+          const jobs      = jobsArray.filter(job => job);
+          // Maybe we were requested to shut down while waiting
+          // for jobs. Don't process, try to release them instead.
+          if (this._processing) {
+            this._activeJobs += jobs.length;
+            jobs.forEach(job => {
+              this._runAndDestroy(client, job)
+                .then(() => --this._activeJobs)
+                .then(() => this._processContinuously(client));
+            });
+          } else
+            jobs.forEach(job => releaseJob(job));
+        })
+        .catch(() => {
+          this._reserving = false;
+          return Bluebird.delay(backoff);
+        })
         .then(() => this._processContinuously(client));
     }
     return null;
@@ -322,17 +347,20 @@ class Queue {
     function releaseJob(job) {
       const jobID         = job.id;
       const reservationID = job.reservation_id;
-      client.msg_release(jobID, reservationID, { delay: 0 });
+      client.msg_release(jobID, reservationID, { delay: 0 }, function(releaseError) {
+        if (releaseError)
+          debug('Could not release job %s:%s', this.name, job.id, releaseError);
+      });
     }
   }
 
 
   // _reserveAndProcess and _processContinuously use this
-  _reserveJob(client, wait) {
+  _reserveJob(client, wait, maxJobs) {
     return new Promise(function(resolve, reject) {
       const timeout = msToSec(PROCESSING_TIMEOUT);
 
-      client.reserve({ timeout, wait }, function(error, job) {
+      client.reserve({ timeout, wait, n: maxJobs }, function(error, job) {
         if (error && /not found/i.test(error.message))
           resolve(); // IronMQ v3 API
         else if (error && /^TIMED_OUT/.test(error.message))
@@ -431,36 +459,14 @@ class Queue {
   purgeQueue() {
     // We're using the _putClient session (use), the _reserve session (watch) doesn't
     // return any jobs.
-    return this._putClientPromise.then(peekAndDelete);
-
-    function peekAndDelete(client) {
-      return new Promise(function(resolve, reject) {
-        client.peek({ n: 100 }, function(error, ids) {
-          if (error && /not found/i.test(error))
-            resolve();
-          else if (error)
-            reject(error);
-          else if (ids.length) {
-            const deleteEach  = ids.map(id => deleteAsync(client, id));
-            const deleteAll   = Promise.all(deleteEach);
-            const andRepeat   = deleteAll.then(() => peekAndDelete(client));
-            resolve(andRepeat);
-          } else
-            resolve();
-        });
+    return this._putClientPromise
+      .then(client => Bluebird.promisify(client.clear.bind(client))())
+      .catch(error => {
+        if (error.message === 'Queue not found')
+          return;
+        else
+          throw error;
       });
-    }
-
-    function deleteAsync(client, jobID) {
-      return new Promise(function(resolve, reject) {
-        client.del(jobID, {}, function(error) {
-          if (error)
-            reject(error);
-          else
-            resolve();
-        });
-      });
-    }
   }
 
 

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -136,7 +136,6 @@ class Queue {
 
     this._handlers    = new Set();
     this._processing  = false;
-    this._reserving   = false;
     this._activeJobs  = 0;
 
     // Used to limit concurrency for stream processing (see throttle method)
@@ -299,9 +298,7 @@ class Queue {
 
   // Called to process all jobs, until this._processing is set to false.
   _processContinuously(client) {
-    if (this._processing && !this._reserving) {
-      this._reserving = true;
-
+    if (this._processing) {
       const backoff = ifProduction(RESERVE_BACKOFF);
       const wait    = (process.env.NODE_ENV === 'test' ? 0 : msToSec(RESERVE_WAIT));
 
@@ -318,7 +315,6 @@ class Queue {
           }
         })
         .then(jobOrJobs => {
-          this._reserving = false;
           // With Beanstalk, or when n=1, we get a single job.
           // Job objects are never arrays (their body could be).
           const jobsArray = Array.isArray(jobOrJobs) ? jobOrJobs : [jobOrJobs];
@@ -330,16 +326,13 @@ class Queue {
             this._activeJobs += jobs.length;
             jobs.forEach(job => {
               this._runAndDestroy(client, job)
-                .then(() => --this._activeJobs)
-                .then(() => this._processContinuously(client));
+                .then(() => --this._activeJobs);
             });
           } else
             jobs.forEach(job => releaseJob(job));
         })
-        .catch(() => {
-          this._reserving = false;
-          return Bluebird.delay(backoff);
-        })
+        // Back off from reserving if Beanstalk/IronMQ are down.
+        .catch(() => Bluebird.delay(backoff))
         .then(() => this._processContinuously(client));
     }
     return null;

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -288,7 +288,6 @@ class Queue {
 
   // Calls _processContinuously for each session
   _startProcessing() {
-    // const width = Math.max(isNaN(this._width) ? 1 : this._width, 1);
     this._server.configPromise
       .then(config => {
         this._getClientPromise

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -293,7 +293,7 @@ class Queue {
       .then(client => {
         this._processContinuously(client);
         return null;
-      })
+      });
   }
 
   // Called to process all jobs, until this._processing is set to false.

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -288,12 +288,15 @@ class Queue {
 
   // Calls _processContinuously for each session
   _startProcessing() {
-    const width = Math.max(isNaN(this._width) ? 1 : this._width, 1);
-    this._getClientPromise
-      .then(client => {
-        for (let i = 0; i < width; ++i)
-          this._processContinuously(client);
-        return null;
+    // const width = Math.max(isNaN(this._width) ? 1 : this._width, 1);
+    this._server.configPromise
+      .then(config => {
+        this._getClientPromise
+          .then(client => {
+            for (let i = 0; i < config.concurrency; ++i)
+              this._processContinuously(client);
+            return null;
+          });
       });
   }
 

--- a/test/processing/continuously_test.js
+++ b/test/processing/continuously_test.js
@@ -1,6 +1,7 @@
 'use strict';
-const assert = require('assert');
-const fork   = require('child_process').fork;
+const assert  = require('assert');
+const fork    = require('child_process').fork;
+const Ironium = require('../..');
 
 
 const isMocha = !!global.describe;
@@ -17,6 +18,10 @@ function runTestSuite() {
 
     var child   = null;
     const steps = [];
+
+    before(function() {
+      Ironium.configure({ concurrency: 1 });
+    });
 
     before(function(done) {
       child = fork(module.filename, { env: { NODE_ENV: 'test', DEBUG: process.env.DEBUG } });

--- a/test/processing/parallel_test.js
+++ b/test/processing/parallel_test.js
@@ -2,42 +2,86 @@
 require('../helpers');
 const assert   = require('assert');
 const Bluebird = require('bluebird');
+const File     = require('fs');
 const Ironium  = require('../..');
 
 
-describe('Processing', ()=> {
+describe('Processing', () => {
+  let ironMQConfig;
 
-  const processSerialQueue   = Ironium.queue('process-serial');
-  const processParallelQueue = Ironium.queue('process-parallel');
 
   function createHandler(chain) {
     return function(job) {
-      chain.push('A');
+      chain.push(job);
       return Bluebird.delay(10)
         .then(() => {
-          chain.push('B');
+          chain.push(job);
         });
     };
   }
 
+  before(function() {
+    ironMQConfig = JSON.parse(File.readFileSync('iron.json'));
+  });
 
-  describe('serially', ()=> {
+
+  describe('serially', () => {
+    let processSerialQueue;
     const chain = [];
 
-    before(()=> {
-      Ironium.configure({ concurrency: 1 });
+    before(() => {
+      const withoutConcurrency = Object.assign({}, ironMQConfig, { concurrency: 1 });
+      Ironium.configure(withoutConcurrency);
+      processSerialQueue = Ironium.queue('process-serial');
+    });
+
+    before(Ironium.purgeQueues);
+
+    before(() => {
       processSerialQueue.eachJob(createHandler(chain));
     });
 
     before(function() {
-      const jobs = [1, 2].map((job)=> processSerialQueue.queueJob(job));
-      return Promise.all(jobs);
+      return Bluebird.each(['A', 'B'], job => processSerialQueue.queueJob(job));
     });
 
     before(Ironium.start);
-    before((done)=> setTimeout(done, 100));
+    before((done) => setTimeout(done, 2000));
 
-    it('should run jobs in sequence', ()=> {
+    it('should run jobs in sequence', () => {
+      assert.equal(chain.join(''), 'AABB');
+    });
+
+    after(Ironium.stop);
+    after(function(done) {
+      setTimeout(done, 100);
+    });
+  });
+
+
+  describe('with concurrency - simple', () => {
+    let processParallelQueue;
+    const chain = [];
+
+    before(() => {
+      Ironium.configure(ironMQConfig);
+      processParallelQueue = Ironium.queue('process-parallel');
+    });
+
+    before(Ironium.purgeQueues);
+
+    before(() => {
+      processParallelQueue.eachJob(createHandler(chain));
+    });
+
+    before(function() {
+      return Bluebird.each(['A', 'B'], job => processParallelQueue.queueJob(job));
+    });
+
+    before(Ironium.start);
+    before(done => setTimeout(done, 2000));
+
+    it('should run jobs in parallel', () => {
       assert.equal(chain.join(''), 'ABAB');
     });
 
@@ -48,29 +92,41 @@ describe('Processing', ()=> {
   });
 
 
-  describe('with default concurrency', ()=> {
+  describe('with concurrency - throttled', () => {
+    let processParallelQueue;
     const chain = [];
 
+    before(() => {
+      const withLimitedConcurrency = Object.assign({}, ironMQConfig, { concurrency: 2 });
+      Ironium.configure(withLimitedConcurrency);
+      processParallelQueue = Ironium.queue('process-parallel');
+    });
+
     before(Ironium.purgeQueues);
-    before(()=> {
-      Ironium.configure({});
+
+    before(() => {
       processParallelQueue.eachJob(createHandler(chain));
     });
-    before(function() {
-      const jobs = [3, 4].map((job)=> processParallelQueue.queueJob(job));
-      return Promise.all(jobs);
-    });
-    before(Ironium.start);
-    before((done)=> setTimeout(done, 100));
 
-    it('should run jobs in parallel', ()=> {
-      assert.equal(chain.join(''), 'AABB');
+    before(function() {
+      const jobs = [1, 2, 3, 4, 5, 6];
+      return Bluebird.each(jobs, job => processParallelQueue.queueJob(job));
+    });
+
+    before(Ironium.start);
+    before(done => setTimeout(done, 4000));
+
+    it('should run jobs in parallel', () => {
+      assert.equal(chain.join(''), '121234345656');
     });
 
     after(Ironium.stop);
-    after(function(done) {
-      setTimeout(done, 100);
-    });
+    after(done => setTimeout(done, 100));
+  });
+
+
+  after(function() {
+    Ironium.configure({});
   });
 
 });


### PR DESCRIPTION
- Adds configurable concurrency to Ironium.
- `Ironium.configure({ concurrency: 20 })`
- When using IronMQ, multiple jobs are reserved at the same time.
- Only one blocking call to reserve per queue.
- Default concurrency is 10.
