### PR TITLE
Queue multiple jobs in a single call

### DIFF
--- a/lib/beanstalk.js
+++ b/lib/beanstalk.js
@@ -218,11 +218,15 @@ module.exports = class Beanstalk {
       .catch(callback);
   }
 
-  post(params, callback) {
+  post(messageOrMessages, callback) {
+    const messages = Array.isArray(messageOrMessages) ? messageOrMessages : [messageOrMessages];
     const priority = 0;
     const timeout  = ms('10m');
-    return this.request('put', priority, params.delay, timeout, params.body)
-      .then(id => callback(null, id), callback);
+    const promises = messages.map(message => {
+      return this.request('put', priority, message.delay, timeout, message.body);
+    });
+    return Promise.all(promises)
+      .then(ids => callback(null, ids), callback);
   }
 
   reserve(options, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,7 @@ class Ironium  {
     this.eachJob        = Ironium.prototype.eachJob.bind(this);
     this.queue          = Ironium.prototype.queue.bind(this);
     this.queueJob       = Ironium.prototype.queueJob.bind(this);
+    this.queueJobs      = Ironium.prototype.queueJobs.bind(this);
     this.scheduleJob    = Ironium.prototype.scheduleJob.bind(this);
     this.start          = Ironium.prototype.start.bind(this);
     this.stop           = Ironium.prototype.stop.bind(this);
@@ -67,6 +68,15 @@ class Ironium  {
   // Same as queue(queueName).queueJob(job)
   queueJob(queueName, job) {
     return this.queue(queueName).queueJob(job);
+  }
+
+  // Queues multiple jobs in the named queue.
+  //
+  // Returns a promise that resolves to an array of job IDs.
+  //
+  // Same as queue(queueName).queueJobs(job)
+  queueJobs(queueName, jobs) {
+    return this.queue(queueName).queueJobs(jobs);
   }
 
   // Schedules a new job to run periodically/once.

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -154,30 +154,50 @@ class Queue {
     return this.delayJob(job, 0);
   }
 
+  // Queue multiple jobs with no delay.
+  queueJobs(jobs) {
+    return this.delayJobs(jobs, 0);
+  }
+
   // Push job to queue with the given delay.  Delay can be millisecond,
   // or a string of the form '5s', '2m', etc.
   delayJob(job, duration) {
-    assert(job != null,       'Missing job to queue');
-    assert(duration.toString, 'Delay must be string or number');
+    return this.delayJobs([ job ], duration)
+      .then(jobIDs => jobIDs[0]);
+  }
+
+  // Push jobs to queue with the given delay.  Delay can be millisecond,
+  // or a string of the form '5s', '2m', etc.
+  delayJobs(jobs, duration) {
+    assert(jobs.every(job => job), 'Job cannot be null');
+    assert(duration.toString,      'Delay must be string or number');
 
     // Converts '5m' to 300 seconds.  The toString is necessary to handle
     // numbers properly, since ms(number) -> string.
     const delay   = msToSec(ms(duration.toString()));
-    const body    = Buffer.isBuffer(job) ? job.toString() : JSON.stringify(job);
+
+    const messages = jobs.map(function(job) {
+      const body = Buffer.isBuffer(job) ? job.toString() : JSON.stringify(job);
+      return { body, delay };
+    });
 
     const queue   = this;
-    ++this._queuing;
+    this._queuing += jobs.length;
     return this._putClientPromise.then(postJob);
 
     function postJob(client) {
       return new Promise(function(resolve, reject) {
-        client.post({ body, delay }, function(error, jobID) {
+        client.post(messages, function(error, jobIDs) {
           if (error)
-            // This will typically be connection error, not helpful until we include the queue name.
+            // This will typically be connection error,
+            // not helpful until we include the queue name.
             reject(new Error(`Error queuing to ${queue.name}: ${error.message}`));
           else {
-            debug('Queued job %s on queue %s', jobID, queue.name, body);
-            resolve(jobID);
+            jobIDs.forEach(function(jobID, index) {
+              const body = messages[index].body;
+              debug('Queued job %s on queue %s', jobID, queue.name, body);
+            });
+            resolve(jobIDs);
             setImmediate(decrementQueuingCount);
           }
         });
@@ -185,7 +205,7 @@ class Queue {
     }
 
     function decrementQueuingCount() {
-      --queue._queuing;
+      queue._queuing -= jobs.length;
       queue._emitter.emit('ready');
     }
   }

--- a/test/queue/multiple_test.js
+++ b/test/queue/multiple_test.js
@@ -1,0 +1,108 @@
+'use strict';
+require('../helpers');
+const assert  = require('assert');
+const Ironium = require('../..');
+
+
+describe('Queue multiple jobs', function() {
+
+  const captureQueue = Ironium.queue('capture');
+  const processed    = [];
+
+  // Capture processed jobs here.
+  before(() => {
+    captureQueue.eachJob((job, callback) => {
+      processed.push(job);
+      callback();
+    });
+  });
+
+
+  describe('objects', () => {
+    before(() => processed.splice(0));
+    before(() => captureQueue.queueJobs([{ id: 5 }, { id: 6 }]));
+    before(Ironium.runOnce);
+
+    it('should process the first object', () => {
+      assert.equal(processed[0].id, 5);
+    });
+
+    it('should process the second object', () => {
+      assert.equal(processed[1].id, 6);
+    });
+  });
+
+
+  describe('an array', () => {
+    before(() => processed.splice(0));
+    before(() => captureQueue.queueJobs([[true, '+'], [false, '-']]));
+    before(Ironium.runOnce);
+
+    it('should process the first array', () => {
+      assert.equal(processed[0][0], true);
+      assert.equal(processed[0][1], '+');
+    });
+
+    it('should process the second array', () => {
+      assert.equal(processed[1][0], false);
+      assert.equal(processed[1][1], '-');
+    });
+  });
+
+
+  describe('buffers', () => {
+
+    describe('(JSON)', () => {
+      before(() => processed.splice(0));
+      before(() => {
+        const b1 = new Buffer('{ "x": 1 }');
+        const b2 = new Buffer('{ "y": 2 }');
+        return captureQueue.queueJobs([ b1, b2 ]);
+      });
+      before(Ironium.runOnce);
+
+      it('should process the first buffer as object value', () => {
+        assert.equal(processed[0].x, 1);
+      });
+
+      it('should process the second buffer as object value', () => {
+        assert.equal(processed[1].y, 2);
+      });
+    });
+
+
+    describe('(not JSON)', () => {
+      before(() => processed.splice(0));
+      before(() => {
+        const b1 = new Buffer('x + 1');
+        const b2 = new Buffer('y + 2');
+        return captureQueue.queueJobs([ b1, b2 ]);
+      });
+      before(Ironium.runOnce);
+
+      it('should process the first buffer as string value', () => {
+        assert.equal(processed[0], 'x + 1');
+      });
+
+      it('should process the second buffer as string value', () => {
+        assert.equal(processed[1], 'y + 2');
+      });
+    });
+
+  });
+
+
+  describe('a null', () => {
+    before(() => processed.splice(0));
+
+    it('should error', done => {
+      assert.throws(() => {
+        captureQueue.queueJobs([ null ], done);
+      });
+      assert.equal(processed.length, 0);
+      done();
+    });
+  });
+
+});
+


### PR DESCRIPTION
- `Ironium.queueJobs(queueName, jobs)`
- Only supported in IronMQ.
- Triggers multiple calls to Beanstalk.
