### PR TITLE
Add feature to Ironium to test delayed jobs with Timekeeper in test enviroment 

### DIFF
--- a/lib/beanstalk.js
+++ b/lib/beanstalk.js
@@ -195,6 +195,10 @@ module.exports = class Beanstalk {
       });
   }
 
+  kickJob(jobID) {
+    return this.request('kick_job', jobID);
+  }
+
   del(message) {
     return this.request('destroy', message.id);
   }

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -299,10 +299,10 @@ class Queue {
   _getDelayedJobIDs() {
     const jobIDs = [];
 
-    for (const [ id, readyTime ] of this._delayedJobs) {
+    this._delayedJobs.forEach(function(readyTime, id) {
       if (readyTime <= Date.now())
         jobIDs.push(id);
-    }
+    });
 
     return jobIDs;
   }

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -164,17 +164,7 @@ class Queue {
   // Push job to queue with the given delay.  Delay can be millisecond,
   // or a string of the form '5s', '2m', etc.
   delayJob(job, duration) {
-    const self = this;
-
-    return this.delayJobs([ job ], duration)
-      .then(function(jobIDs) {
-
-        if (process.env.NODE_ENV === 'test')
-          self._delayedJobs.set(jobIDs[0], Date.now() + ms(duration));
-
-        return jobIDs[0];
-      });
-
+    return this.delayJobs([ job ], duration);
   }
 
   // Push jobs to queue with the given delay.  Delay can be millisecond,
@@ -204,7 +194,17 @@ class Queue {
             const bodyHash = self._hashBody(body);
             debug('Queued job %s on queue %s', jobID, self.name, bodyHash);
           });
+
           setImmediate(decrementQueuingCount);
+
+          const msDelay = delay * 1000;
+
+          if (process.env.NODE_ENV === 'test' && msDelay > 0) {
+            jobIDs.map(function(id) {
+              self._delayedJobs.set(id, Date.now() + msDelay);
+            });
+          }
+
           return jobIDs;
         })
         .catch(function(error) {
@@ -275,11 +275,11 @@ class Queue {
 
       debug('Waiting for jobs on queue %s', this.name);
 
-      if (process.env.NODE_ENV === 'test' && this._delayedJobs.size > 0) {
+      if (this._delayedJobs.size > 0) {
 
-        const jobIDs = getReadyJobIDs(this);
+        const jobIDs = this._getDelayedJobIDs();
 
-        return kickJobs(this, jobIDs)
+        return this._kickJobs(jobIDs)
           .then(() => this._getClientPromise)
           .then(client => this._reserveAndProcess(client));
 
@@ -292,42 +292,41 @@ class Queue {
 
     } else
       return Promise.resolve(false);
-
-    function getReadyJobIDs(queue) {
-      const jobIDs = [];
-
-      for (const [ id, readyTime ] of queue._delayedJobs) {
-        if (readyTime <= Date.now())
-          jobIDs.push(id);
-      }
-
-      return jobIDs;
-    }
-
-    function kickJobs(queue, jobIDs) {
-      return queue._putClientPromise
-        .then(function(client) {
-          const promises = [];
-
-          for (const id of jobIDs) {
-
-            const promise = client.kickJob(id)
-              .then(() => queue._delayedJobs.delete(id))
-              .catch(function(error) {
-                if (error.message === 'NOT_FOUND')
-                  debug(`Could not find and delete job with id: ${id}`);
-                else
-                  throw new Error(`Error deleting job with id: ${id} with message: ${error.message}`);
-              });
-
-            promises.push(promise);
-          }
-
-          return Promise.all(promises);
-        });
-    }
   }
 
+
+  // Returns a list of stored delayed jobs IDs that are ready to be processed
+  _getDelayedJobIDs() {
+    const jobIDs = [];
+
+    for (const [ id, readyTime ] of this._delayedJobs) {
+      if (readyTime <= Date.now())
+        jobIDs.push(id);
+    }
+
+    return jobIDs;
+  }
+
+
+  // Moves delayed jobs to the ready queue (to be processed) in test mode
+  _kickJobs(jobIDs) {
+    const self = this;
+
+    return self._putClientPromise
+      .then(function(client) {
+
+        return Bluebird.map(jobIDs, function(id) {
+          return client.kickJob(id)
+            .then(() => self._delayedJobs.delete(id))
+            .catch(function(error) {
+              if (error.message === 'NOT_FOUND')
+                debug(`Could not find and delete job with id: ${id}`);
+              else
+                throw new Error(`Error deleting job with id: ${id} with message: ${error.message}`);
+            });
+        });
+      });
+  }
 
   // For stream processing, we want to throttle the stream based on our queuing
   // bandwidth.  The callback is called when it's good time to queue the next

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -164,7 +164,8 @@ class Queue {
   // Push job to queue with the given delay.  Delay can be millisecond,
   // or a string of the form '5s', '2m', etc.
   delayJob(job, duration) {
-    return this.delayJobs([ job ], duration);
+    return this.delayJobs([ job ], duration)
+      .then(jobIDs => jobIDs[0]);
   }
 
   // Push jobs to queue with the given delay.  Delay can be millisecond,
@@ -200,7 +201,7 @@ class Queue {
           const msDelay = delay * 1000;
 
           if (process.env.NODE_ENV === 'test' && msDelay > 0) {
-            jobIDs.map(function(id) {
+            jobIDs.forEach(function(id) {
               self._delayedJobs.set(id, Date.now() + msDelay);
             });
           }
@@ -275,20 +276,11 @@ class Queue {
 
       debug('Waiting for jobs on queue %s', this.name);
 
-      if (this._delayedJobs.size > 0) {
+      const jobIDs = this._getReadyDelayedJobIDs();
 
-        const jobIDs = this._getDelayedJobIDs();
-
-        return this._kickJobs(jobIDs)
-          .then(() => this._getClientPromise)
-          .then(client => this._reserveAndProcess(client));
-
-      } else {
-
-        return this._getClientPromise
-          .then(client => this._reserveAndProcess(client));
-
-      }
+      return this._kickJobs(jobIDs)
+        .then(() => this._getClientPromise)
+        .then(client => this._reserveAndProcess(client));
 
     } else
       return Promise.resolve(false);
@@ -296,7 +288,7 @@ class Queue {
 
 
   // Returns a list of stored delayed jobs IDs that are ready to be processed
-  _getDelayedJobIDs() {
+  _getReadyDelayedJobIDs() {
     const jobIDs = [];
 
     this._delayedJobs.forEach(function(readyTime, id) {

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -138,6 +138,7 @@ class Queue {
     this._handlers    = new Set();
     this._processing  = false;
     this._activeJobs  = 0;
+    this._delayedJobs = new Map();
 
     // Used to limit concurrency for stream processing (see throttle method)
     this._queuing     = 0;
@@ -164,8 +165,17 @@ class Queue {
   // Push job to queue with the given delay.  Delay can be millisecond,
   // or a string of the form '5s', '2m', etc.
   delayJob(job, duration) {
+    const self = this;
+
     return this.delayJobs([ job ], duration)
-      .then(jobIDs => jobIDs[0]);
+      .then(function(jobIDs) {
+
+        if (process.env.NODE_ENV === 'test')
+          self._delayedJobs.set(jobIDs[0], Date.now() + ms(duration));
+
+        return jobIDs[0];
+      });
+
   }
 
   // Push jobs to queue with the given delay.  Delay can be millisecond,
@@ -261,13 +271,54 @@ class Queue {
   runOnce() {
     assert(!this._processing, 'Cannot call once while continuously processing jobs');
     const hasHandlers = (this._handlers.size > 0);
+
     if (hasHandlers) {
 
       debug('Waiting for jobs on queue %s', this.name);
-      return this._getClientPromise.then(client => this._reserveAndProcess(client));
+
+      if (process.env.NODE_ENV === 'test' && this._delayedJobs.size > 0) {
+
+        const jobIDs = getReadyJobIDs(this);
+
+        return kickJobs(this, jobIDs)
+          .then(() => this._getClientPromise)
+          .then(client => this._reserveAndProcess(client));
+
+      } else {
+
+        return this._getClientPromise
+          .then(client => this._reserveAndProcess(client));
+
+      }
 
     } else
       return Promise.resolve(false);
+
+    function getReadyJobIDs(queue) {
+      const jobIDs = [];
+
+      for (const [ id, readyTime ] of queue._delayedJobs) {
+        if (readyTime <= Date.now())
+          jobIDs.push(id);
+      }
+
+      return jobIDs;
+    }
+
+    function kickJobs(queue, jobIDs) {
+      return queue._putClientPromise
+        .then(function(client) {
+          const promises = [];
+
+          for (const id of jobIDs) {
+            const promise = client.kickJob(id).then(() => queue._delayedJobs.delete(id));
+            promises.push(promise);
+          }
+
+          return Promise.all(promises);
+        });
+    }
+
   }
 
 

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -182,7 +182,7 @@ class Queue {
   // or a string of the form '5s', '2m', etc.
   delayJobs(jobs, duration) {
     assert(jobs.every(job => job), 'Job cannot be null');
-    assert(duration.toString,      'Delay must be string or number');
+    assert(duration.toString(), 'Delay must be string or number');
 
     // Converts '5m' to 300 seconds.  The toString is necessary to handle
     // numbers properly, since ms(number) -> string.
@@ -311,14 +311,22 @@ class Queue {
           const promises = [];
 
           for (const id of jobIDs) {
-            const promise = client.kickJob(id).then(() => queue._delayedJobs.delete(id));
+
+            const promise = client.kickJob(id)
+              .then(() => queue._delayedJobs.delete(id))
+              .catch(function(error) {
+                if (error.message === 'NOT_FOUND')
+                  debug(`Could not find and delete job with id: ${id}`);
+                else
+                  throw new Error(`Error deleting job with id: ${id} with message: ${error.message}`);
+              });
+
             promises.push(promise);
           }
 
           return Promise.all(promises);
         });
     }
-
   }
 
 

--- a/test/queue/kick_job_test.js
+++ b/test/queue/kick_job_test.js
@@ -1,15 +1,18 @@
 'use strict';
-require('../helpers');
+
 const assert      = require('assert');
 const Ironium     = require('../..');
 const ms          = require('ms');
 const TimeKeeper  = require('timekeeper');
+const setup       = require('../helpers');
 
 
-describe('Queuing a delayed job in test enviroment', function() {
+describe('Queuing a delayed job in test environment', function() {
 
   const queue         = Ironium.queue('delayedJobQueue');
   const processedJobs = [];
+
+  before(setup);
 
   before(function() {
     queue.eachJob(function(job) {
@@ -17,49 +20,6 @@ describe('Queuing a delayed job in test enviroment', function() {
       return Promise.resolve();
     });
   });
-
-  describe('after a job delayed for 10 minutes is queued', function() {
-
-    before(function() {
-      return queue.delayJob('job', '10m');
-    });
-
-    describe('time traveling 5 minutes', function() {
-
-      before(function() {
-        TimeKeeper.travel(Date.now() + ms('5m'));
-      });
-
-      before(Ironium.runOnce);
-
-      it('should not have processed job', function() {
-        assert.equal(processedJobs.length, 0);
-      });
-
-      after(TimeKeeper.reset);
-
-    });
-
-    describe('time traveling 10 minutes', function() {
-
-      before(function() {
-        TimeKeeper.travel(Date.now() + ms('10m'));
-      });
-
-      before(Ironium.runOnce);
-
-      it('should have processed job', function() {
-        assert.equal(processedJobs[0], 'job');
-      });
-
-      after(TimeKeeper.reset);
-
-    });
-
-
-    after(() => processedJobs.splice(0, processedJobs.length));
-  });
-
 
   describe('after multiple jobs are delayed', function() {
 

--- a/test/queue/kick_job_test.js
+++ b/test/queue/kick_job_test.js
@@ -1,0 +1,58 @@
+'use strict';
+require('../helpers');
+const assert      = require('assert');
+const Ironium     = require('../..');
+const ms          = require('ms');
+const TimeKeeper  = require('timekeeper');
+
+
+describe('Queuing a delayed job in test enviroment', function() {
+
+  const queue         = Ironium.queue('delayedJobQueue');
+  const processedJobs = [];
+
+  before(function() {
+    queue.eachJob(function(job) {
+      processedJobs.push(job);
+      return Promise.resolve();
+    });
+  });
+
+  describe('after a job delayed for 10 minutes is queued', function() {
+
+    before(function() {
+      return queue.delayJob('job', '10m');
+    });
+
+    describe('time traveling 5 minutes', function() {
+
+      before(function() {
+        TimeKeeper.travel(Date.now() + ms('5m'));
+      });
+
+      before(Ironium.runOnce);
+
+      it('should not have processed job', function() {
+        assert.equal(processedJobs.length, 0);
+      });
+
+      describe('time traveling 5 minutes more (10 minutes total)', function() {
+        before(function() {
+          TimeKeeper.travel(Date.now() + ms('5m'));
+        });
+
+        before(Ironium.runOnce);
+
+        it('should have processed job', function() {
+          assert.equal(processedJobs[0], 'job');
+        });
+
+      });
+
+      after(TimeKeeper.reset);
+
+    });
+
+  });
+
+});

--- a/test/queue/kick_job_test.js
+++ b/test/queue/kick_job_test.js
@@ -36,17 +36,94 @@ describe('Queuing a delayed job in test enviroment', function() {
         assert.equal(processedJobs.length, 0);
       });
 
-      describe('time traveling 5 minutes more (10 minutes total)', function() {
-        before(function() {
-          TimeKeeper.travel(Date.now() + ms('5m'));
-        });
+      after(TimeKeeper.reset);
 
-        before(Ironium.runOnce);
+    });
 
-        it('should have processed job', function() {
-          assert.equal(processedJobs[0], 'job');
-        });
+    describe('time traveling 10 minutes', function() {
 
+      before(function() {
+        TimeKeeper.travel(Date.now() + ms('10m'));
+      });
+
+      before(Ironium.runOnce);
+
+      it('should have processed job', function() {
+        assert.equal(processedJobs[0], 'job');
+      });
+
+      after(TimeKeeper.reset);
+
+    });
+
+
+    after(() => processedJobs.splice(0, processedJobs.length));
+  });
+
+
+  describe('after multiple jobs are delayed', function() {
+
+    before(function() {
+      return queue.delayJob('job1', '2m');
+    });
+
+    before(function() {
+      return queue.delayJob('job2', '3m');
+    });
+
+
+    describe('time traveling 1 minute', function() {
+
+      before(function() {
+        TimeKeeper.travel(Date.now() + ms('1m'));
+      });
+
+      before(Ironium.runOnce);
+
+      it('should not process any jobs', function() {
+        assert.equal(processedJobs.length, 0);
+      });
+
+      after(TimeKeeper.reset);
+    });
+
+
+    describe('time traveling 2 minutes', function() {
+
+      before(function() {
+        TimeKeeper.travel(Date.now() + ms('2m'));
+      });
+
+      before(Ironium.runOnce);
+
+      it('should have processed \'job1\'', function() {
+        assert.equal(processedJobs[0], 'job1');
+      });
+
+      it('should not have processed \'job2\'', function() {
+        const noJob2 = processedJobs.find(job => job !== 'job2');
+        assert(noJob2);
+      });
+
+      after(TimeKeeper.reset);
+
+    });
+
+
+    describe('time traveling 3 minutes', function() {
+
+      before(function() {
+        TimeKeeper.travel(Date.now() + ms('3m'));
+      });
+
+      before(Ironium.runOnce);
+
+      it('should have processed \'job1\'', function() {
+        assert.equal(processedJobs[0], 'job1');
+      });
+
+      it('should have processed \'job2\'', function() {
+        assert.equal(processedJobs[1], 'job2');
       });
 
       after(TimeKeeper.reset);

--- a/test/queue/with_delay_test.js
+++ b/test/queue/with_delay_test.js
@@ -40,9 +40,8 @@ describe('Queue with delay', function() {
 
   describe('after sufficient delay', function() {
     before(function(done) {
-      setTimeout(done, 500);
+      setTimeout(done, 1000);
     });
-
     before(Ironium.runOnce);
 
     it('should process job', function() {

--- a/test/queue/with_delay_test.js
+++ b/test/queue/with_delay_test.js
@@ -1,9 +1,7 @@
 'use strict';
 require('../helpers');
-const assert      = require('assert');
-const Ironium     = require('../..');
-const ms          = require('ms');
-const TimeKeeper  = require('timekeeper');
+const assert  = require('assert');
+const Ironium = require('../..');
 
 
 describe('Queue with delay', function() {
@@ -21,20 +19,18 @@ describe('Queue with delay', function() {
   });
 
   before(function() {
-    return captureQueue.delayJob('delayed', '2m');
+    return captureQueue.delayJob('delayed', '2s');
   });
-
   before(Ironium.runOnce);
 
   it('should not process immediately', function() {
     assert.equal(processed.length, 0);
   });
 
-  describe('after 1 minute', function() {
-    before(function() {
-      TimeKeeper.travel(Date.now() + ms('1m'));
+  describe('after short delay', function() {
+    before(function(done) {
+      setTimeout(done, 1500);
     });
-
     before(Ironium.runOnce);
 
     it('should not process job', function() {
@@ -42,9 +38,9 @@ describe('Queue with delay', function() {
     });
   });
 
-  describe('after 2 minutes', function() {
-    before(function() {
-      TimeKeeper.travel(Date.now() + ms('2m'));
+  describe('after sufficient delay', function() {
+    before(function(done) {
+      setTimeout(done, 500);
     });
 
     before(Ironium.runOnce);

--- a/test/queue/with_delay_test.js
+++ b/test/queue/with_delay_test.js
@@ -1,7 +1,9 @@
 'use strict';
 require('../helpers');
-const assert  = require('assert');
-const Ironium = require('../..');
+const assert      = require('assert');
+const Ironium     = require('../..');
+const ms          = require('ms');
+const TimeKeeper  = require('timekeeper');
 
 
 describe('Queue with delay', function() {
@@ -19,18 +21,20 @@ describe('Queue with delay', function() {
   });
 
   before(function() {
-    return captureQueue.delayJob('delayed', '2s');
+    return captureQueue.delayJob('delayed', '2m');
   });
+
   before(Ironium.runOnce);
 
   it('should not process immediately', function() {
     assert.equal(processed.length, 0);
   });
 
-  describe('after short delay', function() {
-    before(function(done) {
-      setTimeout(done, 1500);
+  describe('after 1 minute', function() {
+    before(function() {
+      TimeKeeper.travel(Date.now() + ms('1m'));
     });
+
     before(Ironium.runOnce);
 
     it('should not process job', function() {
@@ -38,10 +42,11 @@ describe('Queue with delay', function() {
     });
   });
 
-  describe('after sufficient delay', function() {
-    before(function(done) {
-      setTimeout(done, 1000);
+  describe('after 2 minutes', function() {
+    before(function() {
+      TimeKeeper.travel(Date.now() + ms('2m'));
     });
+
     before(Ironium.runOnce);
 
     it('should process job', function() {


### PR DESCRIPTION
Issue: https://github.com/assaf/ironium/issues/48

- Currently, there is no easy way to determine when a delayedJob has been processed without moving the system time forward (stubbing system time, or waiting out the duration with `setTimeout`)
- Solution: keep track of the queued time a of a job in a data structure, and kick the job when the queued time + the duration of the delay is less than or the same as the current time (Date.now). Allows the user to test one or more delayed jobs in test environment with Timekeeper. 
- Also: fixes an assertion in delayedJobs where `toString` is not called in the assertion (?)