### PR TITLE
Handlers should get their own copy of the job payload.

### DIFF
--- a/lib/queues.js
+++ b/lib/queues.js
@@ -443,11 +443,13 @@ class Queue {
 
 
     function runHandlers() {
-      const body = parseBody(job.body);
       debug('Processing queued job %s:%s', self.name, jobID, bodyHash);
 
       const handlers = Array.from(self._handlers);
-      const promises = handlers.map(handler => runJob(jobID, handler, [body], PROCESSING_TIMEOUT));
+      const promises = handlers.map(function(handler) {
+        const body = parseBody(job.body);
+        return runJob(jobID, handler, [body], PROCESSING_TIMEOUT);
+      });
       return Promise.all(promises);
     }
 

--- a/test/processing/handlers_test.js
+++ b/test/processing/handlers_test.js
@@ -13,12 +13,13 @@ describe('Processing jobs', function() {
 
   describe('with three handlers', function() {
 
-    // Count how many steps run
-    const steps = new Set();
+    // Record jobs run
+    const jobs  = [];
 
     function recordTheStep(step) {
-      return function() {
-        steps.add(step);
+      return function(job) {
+        job.step = step; // eslint-disable-line no-param-reassign
+        jobs.push(job);
         return Promise.resolve();
       };
     }
@@ -27,12 +28,18 @@ describe('Processing jobs', function() {
       runMultipleQueue.eachJob(recordTheStep('A'));
       runMultipleQueue.eachJob(recordTheStep('B'));
       runMultipleQueue.eachJob(recordTheStep('C'));
-      return runMultipleQueue.queueJob('job');
+      return runMultipleQueue.queueJob({ foo: '1' });
     });
     before(Ironium.runOnce);
 
     it('should run all three steps', function() {
-      assert.equal(steps.size, 3);
+      assert.equal(jobs.length, 3);
+    });
+
+    it('should provide each handler with a copy of the payload', function() {
+      assert.equal(jobs[0].step, 'A');
+      assert.equal(jobs[1].step, 'B');
+      assert.equal(jobs[2].step, 'C');
     });
 
   });


### PR DESCRIPTION
Mutating an argument isn't a good practice, but if we guarantee each handler gets its own copy, we can save developer a lot of debugging time.