### PR TITLE
Log full job on error.

### DIFF
--- a/lib/queues.js
+++ b/lib/queues.js
@@ -502,7 +502,8 @@ class Queue {
       const domain = Domain.createDomain();
       domain.jobID = jobID;
       domain.run(function() {
-        debug('Error processing queued job %s:%s', self.name, jobID, error);
+        const jobForLogging = Object.assign({}, job, { body: parseBody(job.body) });
+        debug('Error processing queued job in %s: %O', self.name, jobForLogging, error);
       });
     }
 


### PR DESCRIPTION
```
ironium:queues Error processing queued job in foo-queue: { id: '3003',
ironium:queues   body: { foo: 1 },
ironium:queues   reservedCount: 1,
ironium:queues   reservationID: '3003' } Error: fail
  at countAndFailJob (./test/processing/error_test.js:23:29)
  at Domain.<anonymous> (./lib/run_job.js:43:30)
  at Domain.run (domain.js:221:14)
  at ./lib/run_job.js:42:12
  at runJob (./lib/run_job.js:26:19)
  at ./lib/queues.js:451:16
  at Array.map (native)
  at runHandlers (./lib/queues.js:449:33)
  at process._tickDomainCallback (internal/process/next_tick.js:135:7) +1ms
```

When using SQS, this will log the receipt handle too, so you can delete a bogus job from the command line.