### PR TITLE
Allow whitelisting of queues to be processed.

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -23,9 +23,13 @@ module.exports = class Configuration {
     const defaultConcurrency = process.env.IRONIUM_CONCURRENCY ?
                                  parseInt(process.env.IRONIUM_CONCURRENCY, 10) :
                                  50;
+    const defaultQueues      = process.env.IRONIUM_QUEUES ?
+                                 process.env.IRONIUM_QUEUES.split(',').map(name => name.trim()) :
+                                 [];
 
     this.prefix      = config.prefix      || defaultPrefix;
     this.concurrency = config.concurrency || defaultConcurrency;
+    this.queues      = config.queues      || defaultQueues;
 
     if (config.project_id || config.token) {
       // Configurating for IronMQ similar to iron.json

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -638,8 +638,13 @@ module.exports = class Queues {
     if (!this._queues.has(queueName)) {
 
       const queue = new Queue(this, queueName);
-      if (this.started)
-        queue.start();
+      if (this.started) {
+        this._shouldStartQueue(queue)
+          .then(shouldStart => {
+            if (shouldStart)
+              queue.start();
+          });
+      }
       this._queues.set(queueName, queue);
 
     }
@@ -650,8 +655,13 @@ module.exports = class Queues {
   start() {
     debug('Start all queues');
     this.started = true;
-    for (const queue of this._queues.values())
-      queue.start();
+    return Bluebird.each(this._queues.values(), queue => {
+      return this._shouldStartQueue(queue)
+        .then(shouldStart => {
+          if (shouldStart)
+            queue.start();
+        });
+    });
   }
 
   // Stops processing jobs from all queues.
@@ -746,6 +756,16 @@ module.exports = class Queues {
         const maxCapacityPerQueue = Math.max(Math.floor(config.concurrency * 0.5), 1);
         const capacity            = Math.min(totalCapacity, maxCapacityPerQueue);
         return capacity;
+      });
+  }
+
+  _shouldStartQueue(queue) {
+    return this.configPromise
+      .then(config => {
+        if (config.queues.length)
+          return config.queues.indexOf(queue.name) > -1;
+        else
+          return true;
       });
   }
 };

--- a/test/processing/aws_credentials_test.js
+++ b/test/processing/aws_credentials_test.js
@@ -24,6 +24,11 @@ const setup        = require('../helpers');
   before(setup);
 
   before(function() {
+    Ironium._queues._queues.clear();
+    Ironium._scheduler._schedules.clear();
+  });
+
+  before(function() {
     runs = 0;
   });
 

--- a/test/processing/some_queues_test.js
+++ b/test/processing/some_queues_test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert   = require('assert');
+const Bluebird = require('bluebird');
+const Ironium  = require('../..');
+const setup    = require('../helpers');
+
+
+describe('Processing only some queues', function() {
+  let foos;
+  let bars;
+
+  before(setup);
+
+  before(function() {
+    Ironium.configure({ queues: [ 'some-queues-foo' ] });
+  });
+
+  before(function() {
+    foos = [];
+    bars = [];
+
+    Ironium.eachJob('some-queues-foo', function(job) {
+      foos.push(job);
+      return Promise.resolve();
+    });
+
+    Ironium.eachJob('some-queues-bar', function(job) {
+      bars.push(job);
+      return Promise.resolve();
+    });
+  });
+
+  before(function() {
+    return Promise.all([
+      Ironium.queueJob('some-queues-foo', 1),
+      Ironium.queueJob('some-queues-bar', 1)
+    ]);
+  });
+
+  before(Ironium.start);
+
+  before(function(done) {
+    setTimeout(done, 1000);
+  });
+
+  it('should run jobs in the whitelisted queue', function() {
+    assert.deepEqual(foos, [ 1 ]);
+  });
+
+  it('should not run jobs from other queues', function() {
+    assert.deepEqual(bars, []);
+  });
+
+  describe('registering handler after start', function() {
+    let bazs;
+
+    before(function() {
+      bazs = [];
+      Ironium.eachJob('some-queues-baz', function(job) {
+        bazs.push(job);
+        return Promise.resolve();
+      });
+    });
+
+    before(function() {
+      return Ironium.queueJob('some-queues-baz', 1);
+    });
+
+    before(function(done) {
+      setTimeout(done, 100);
+    });
+
+    it('should not run jobs from other queues', function() {
+      assert.deepEqual(bazs, []);
+    });
+  });
+
+  after(Ironium.stop);
+
+  after(function(done) {
+    setTimeout(done, 100);
+  });
+
+  after(function() {
+    Ironium.configure({});
+  });
+});

--- a/test/queue/with_delay_test.js
+++ b/test/queue/with_delay_test.js
@@ -72,6 +72,11 @@ describe('Queue with delay', function() {
   before(setup);
 
   before(function() {
+    Ironium._queues._queues.clear();
+    Ironium._scheduler._schedules.clear();
+  });
+
+  before(function() {
     const config = Object.assign({}, getAWSConfig(), { concurrency: 1 });
     Ironium.configure(config);
     queue = Ironium.queue('foo');

--- a/test/schedule/sqs_fifo_test.js
+++ b/test/schedule/sqs_fifo_test.js
@@ -14,6 +14,11 @@ const setup        = require('../helpers');
   before(setup);
 
   before(function() {
+    Ironium._queues._queues.clear();
+    Ironium._scheduler._schedules.clear();
+  });
+
+  before(function() {
     // FIFO queues available here.
     Ironium.configure(Object.assign({}, getAWSConfig(), { region: 'us-west-2' }));
   });


### PR DESCRIPTION
```js
Ironium.configure({
  queues: [ 'foo', 'bar' ]
});
```

Or

```
env IRONIUM_QUEUES=foo,bar npm run worker
```

Ironium will process jobs only for the selected queues, allowing for more granular scaling of workloads.