### PR TITLE
Exponential delay of failed jobs on SQS.

### DIFF
--- a/lib/queues.js
+++ b/lib/queues.js
@@ -24,9 +24,11 @@ const RESERVE_BACKOFF     = ms('30s');
 const PROCESSING_TIMEOUT  = ms('10m');
 
 // Delay before a released job is available for pickup again. This is our
-// primary mechanism for dealing with load during failures. Ignored in test
-// environment.
-const RELEASE_DELAY       = ms('1m');
+// primary mechanism for dealing with load during failures.
+// Implemented as exponential backoff with jitter, so these bounds are approximate.
+// Ignored in test environment.
+const MIN_RELEASE_DELAY = ms('1m');
+const MAX_RELEASE_DELAY = ms('30m');
 
 // How long to wait when reserving a job (1 minute seems to be the maximum).
 const RESERVE_WAIT        = ms('1m');
@@ -483,7 +485,9 @@ class Queue {
       // Error or timeout: we release the job back to the queue.  Since this
       // may be a transient error condition (e.g. server down), we let it sit
       // in the queue for a while before it becomes available again.
-      const delay = msToSec(ifProduction(RELEASE_DELAY));
+      const delay = msToSec(ifProduction(getReleaseDelay(job.reserveCount || 1)));
+
+      debug('Releasing job %s:%s with delay of %ds', self.name, jobID, delay);
 
       client.release(job, { delay })
         .catch(function(releaseError) {
@@ -766,3 +770,18 @@ module.exports = class Queues {
       });
   }
 };
+
+
+// Exponential backoff with jitter.
+function getReleaseDelay(attempt = 1) {
+  const candidate = MIN_RELEASE_DELAY * Math.pow(2, attempt - 1);
+  const capped    = Math.min(candidate, MAX_RELEASE_DELAY);
+  const jitter    = getRandomNumberBetween(0, capped * 0.2);
+  const result    = parseInt(capped + jitter, 10);
+  return result;
+}
+
+function getRandomNumberBetween(min, max) {
+  // The maximum is exclusive and the minimum is inclusive
+  return Math.floor(Math.random() * (max - min)) + min;
+}

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -485,9 +485,10 @@ class Queue {
       // Error or timeout: we release the job back to the queue.  Since this
       // may be a transient error condition (e.g. server down), we let it sit
       // in the queue for a while before it becomes available again.
-      const delay = msToSec(ifProduction(getReleaseDelay(job.reserveCount || 1)));
+      const delayMs = ifProduction(getReleaseDelay(job.reserveCount || 1));
+      const delay   = msToSec(delayMs);
 
-      debug('Releasing job %s:%s with delay of %ds', self.name, jobID, delay);
+      debug('Releasing job %s:%s with delay of %s', self.name, jobID, ms(delayMs));
 
       client.release(job, { delay })
         .catch(function(releaseError) {

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -85,7 +85,8 @@ module.exports = class SQS {
           QueueUrl:            this.queueURL,
           MaxNumberOfMessages: maxNumberOfMessages,
           VisibilityTimeout:   timeout,
-          WaitTimeSeconds:     waitTimeSeconds
+          WaitTimeSeconds:     waitTimeSeconds,
+          AttributeNames:      [ 'ApproximateReceiveCount' ]
         };
         return sqsClient.receiveMessage(receiveMessageParams).promise();
       })
@@ -97,7 +98,8 @@ module.exports = class SQS {
               body:          msg.Body,
               // ReceiptHandle is what we use to delete or increase visibility
               // timeout for a message.
-              receiptHandle: msg.ReceiptHandle
+              receiptHandle: msg.ReceiptHandle,
+              reserveCount:  parseInt(msg.Attributes.ApproximateReceiveCount, 10)
             };
           });
           return messages;


### PR DESCRIPTION
```
{ attempt: 1, delay: '63s' }   
{ attempt: 2, delay: '129s' }  
{ attempt: 3, delay: '260s' }  
{ attempt: 4, delay: '517s' }  
{ attempt: 5, delay: '1098s' } 
{ attempt: 6, delay: '2094s' } 
{ attempt: 7, delay: '2072s' } 
{ attempt: 8, delay: '2088s' } 
{ attempt: 9, delay: '1938s' } 
{ attempt: 10, delay: '2002s' }
```