### PR TITLE
Allow debugging a specific queue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,9 @@ For example:
 # See processing errors
 DEBUG=ironium npm start
 # See queues and scheduling activity
-DEBUG=ironium:queues,ironium:schedules npm start
+DEBUG=ironium:queues:*,ironium:schedules npm start
+# See activity on specific queue
+DEBUG=ironium:queues:foobar npm start
 # Everything
 DEBUG=ironium:* npm start
 ```

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -141,6 +141,9 @@ class Queue {
     this._processing  = false;
     this._delayedJobs = new Map();
 
+    // Allow to debug specific queues
+    this._debug       = debug.extend(this.name);
+
     // Used to limit concurrency for stream processing (see throttle method)
     this._queuing     = 0;
     this._concurrency = 3;
@@ -276,8 +279,6 @@ class Queue {
 
     if (hasHandlers) {
 
-      debug('Waiting for jobs on queue %s', this.name);
-
       const jobIDs = this._getReadyDelayedJobIDs();
 
       return this._kickJobs(jobIDs)
@@ -367,6 +368,8 @@ class Queue {
 
   // Called to process all jobs, until this._processing is set to false.
   _processContinuously(client) {
+    const debug = this._debug;
+
     if (this._processing) {
       const backoff = ifProduction(RESERVE_BACKOFF);
       const wait    = (process.env.NODE_ENV === 'test' ? 0 : msToSec(RESERVE_WAIT));
@@ -434,6 +437,7 @@ class Queue {
     const self     = this;
     const start    = process.hrtime();
     const bodyHash = self._hashBody(job.body);
+    const debug    = this._debug;
 
     return Promise.resolve()
       .then(runHandlers)


### PR DESCRIPTION
Also remove the debug when waiting to receive jobs at it usually produces too much noise.