### PR TITLE
Pass job metadata to handlers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,20 @@ Ironium.queue('webhook').eachJob(function(job) {
 });
 ```
 
+As of Ironium 7.1, handlers can inspect job metadata by capturing a second argument:
+
+```javascript
+Ironium.queue('echo').eachJob(function(job, metadata) {
+  const { jobID } = metadata;
+
+  // The following available when using SQS
+  const { receiveCount }  = metadata;
+  const { receiptHandle } = metadata;
+});
+
+```
+
+
 ### queue.stream()
 
 You can use this to queue jobs from a Node stream.  It returns a duplex stream

--- a/lib/beanstalk.js
+++ b/lib/beanstalk.js
@@ -230,12 +230,12 @@ module.exports = class Beanstalk {
   reserve(options) {
     return this.request('reserve_with_timeout', options.wait || 0)
       .then(function(job) {
-        const id              = job[0];
-        const body            = job[1];
-        const reservationID   = id;
-        const reservedCount   = 1;
+        const id             = job[0];
+        const body           = job[1];
+        const reservationID  = id;
+        const receiveCount   = 1;
 
-        const message           = { id, body, reservedCount, reservationID };
+        const message           = { id, body, receiveCount, reservationID };
         return [ message ];
       })
       .catch(function(error) {

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -450,6 +450,7 @@ class Queue {
 
     function runHandlers() {
       const metadata = {
+        queueName:     self.name,
         jobID,
         receiveCount:  job.receiveCount,
         receiptHandle: job.receiptHandle

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -449,12 +449,17 @@ class Queue {
 
 
     function runHandlers() {
+      const metadata = {
+        jobID,
+        receiveCount:  job.receiveCount,
+        receiptHandle: job.receiptHandle
+      };
       debug('Processing queued job %s:%s', self.name, jobID, bodyHash);
 
       const handlers = Array.from(self._handlers);
       const promises = handlers.map(function(handler) {
         const body = parseBody(job.body);
-        return runJob(jobID, handler, [body], PROCESSING_TIMEOUT);
+        return runJob(jobID, handler, [body, metadata], PROCESSING_TIMEOUT);
       });
       return Promise.all(promises);
     }
@@ -489,7 +494,7 @@ class Queue {
       // Error or timeout: we release the job back to the queue.  Since this
       // may be a transient error condition (e.g. server down), we let it sit
       // in the queue for a while before it becomes available again.
-      const delayMs = ifProduction(getReleaseDelay(job.reserveCount || 1));
+      const delayMs = ifProduction(getReleaseDelay(job.receiveCount || 1));
       const delay   = msToSec(delayMs);
 
       debug('Releasing job %s:%s with delay of %s', self.name, jobID, ms(delayMs));

--- a/lib/run_job.js
+++ b/lib/run_job.js
@@ -40,6 +40,7 @@ module.exports = function runJob(jobID, handler, args, timeout) {
     }
 
     domain.run(function() {
+      console.log(args);
       const result = handler.apply(null, args);
 
       // Job handler must return a Promise.

--- a/lib/run_job.js
+++ b/lib/run_job.js
@@ -40,7 +40,6 @@ module.exports = function runJob(jobID, handler, args, timeout) {
     }
 
     domain.run(function() {
-      console.log(args);
       const result = handler.apply(null, args);
 
       // Job handler must return a Promise.

--- a/lib/sqs.js
+++ b/lib/sqs.js
@@ -99,7 +99,7 @@ module.exports = class SQS {
               // ReceiptHandle is what we use to delete or increase visibility
               // timeout for a message.
               receiptHandle: msg.ReceiptHandle,
-              reserveCount:  parseInt(msg.Attributes.ApproximateReceiveCount, 10)
+              receiveCount:  parseInt(msg.Attributes.ApproximateReceiveCount, 10)
             };
           });
           return messages;

--- a/test/processing/handlers_test.js
+++ b/test/processing/handlers_test.js
@@ -34,6 +34,7 @@ describe('Processing jobs', function() {
       runMultipleQueue.eachJob(recordTheStep('C'));
       return runMultipleQueue.queueJob({ foo: '1' });
     });
+
     before(Ironium.runOnce);
 
     it('should run all three steps', function() {
@@ -46,6 +47,45 @@ describe('Processing jobs', function() {
       assert.equal(jobs[2].step, 'C');
     });
 
+  });
+
+  describe('handler expecting job metadata', function() {
+    let capturedMetadata;
+
+    before(function() {
+      const queueForMetadata = Ironium.queue('for-metadata');
+      capturedMetadata = [];
+
+      queueForMetadata.eachJob(function(job, metadata) {
+        capturedMetadata.push(metadata);
+        return Promise.resolve();
+      });
+
+      return queueForMetadata.queueJob({ foo: '1' });
+    });
+
+    before(Ironium.runOnce);
+
+    it('should get job ID', function() {
+      const actual   = capturedMetadata[0].jobID;
+      const expected = /^\d+$/;
+
+      assert.match(actual, expected);
+    });
+
+    it('should get reserve count', function() {
+      const actual   = capturedMetadata[0].receiveCount;
+      const expected = 1;
+
+      assert.strictEqual(actual, expected);
+    });
+
+    it('should get receipt handle', function() {
+      const actual   = 'receiptHandle' in capturedMetadata[0];
+      const expected = true;
+
+      assert.strictEqual(actual, expected);
+    });
   });
 
 });

--- a/test/processing/handlers_test.js
+++ b/test/processing/handlers_test.js
@@ -66,6 +66,13 @@ describe('Processing jobs', function() {
 
     before(Ironium.runOnce);
 
+    it('should get queue name', function() {
+      const actual   = capturedMetadata[0].queueName;
+      const expected = 'for-metadata';
+
+      assert.strictEqual(actual, expected);
+    });
+
     it('should get job ID', function() {
       const actual   = capturedMetadata[0].jobID;
       const expected = /^\d+$/;


### PR DESCRIPTION
- Allow handlers to read job metadata by capturing a second argument, see updated README
- Consumers can instrument observability/logging on their own by inspecting the job metadata
- This could pave the way for removing domain code from Ironium https://nodejs.org/en/docs/guides/domain-postmortem/